### PR TITLE
Fix systemd entrypoint

### DIFF
--- a/debian/9/Dockerfile
+++ b/debian/9/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile for Debian jessie
+# Dockerfile for Debian stretch
 FROM debian:stretch
 MAINTAINER Bert Van Vreckem <bert.vanvreckem@gmail.com>
 

--- a/debian/9/Dockerfile
+++ b/debian/9/Dockerfile
@@ -12,14 +12,14 @@ RUN \
     rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
     rm -f /lib/systemd/system/basic.target.wants/*; \
     rm -f /lib/systemd/system/anaconda.target.wants/*; \
-    apt-get update; \
-    apt-get install -y software-properties-common git; \
-    apt-add-repository -y ppa:ansible/ansible; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends sudo ansible python-netaddr; \
+    apt update; \
+    apt install -y software-properties-common git systemd-sysv; \
+    echo 'deb http://http.debian.net/debian stretch-backports main' > /etc/apt/sources.list.d/backports.list; \
+    apt update; \
+    apt -t stretch-backports install -y ansible python-netaddr; \
     rm -rf /var/lib/apt/lists/*; \
     rm -Rf /usr/share/doc && rm -Rf /usr/share/man; \
-    apt-get clean
+    apt clean
 
 RUN mkdir -p /etc/ansible; \
     echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts; \


### PR DESCRIPTION
* Fix entrypoint
* Update ansible version

```
$ docker run --detach --volume=/run --volume=/run/lock --volume=/tmp --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro --cap-add=SYS_ADMIN --cap-add=SYS_RESOURCE --volume=$HOME/.ssh:/root/.ssh debian_9 /sbin/init
```

```
root@b85d68215a17:/# ansible --version
ansible 2.4.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]
```